### PR TITLE
Testing github actions

### DIFF
--- a/.github/workflows/tfplan.yaml
+++ b/.github/workflows/tfplan.yaml
@@ -1,50 +1,40 @@
 name: Terraform plan Dev env
 
 on:
-  push:
-    branches: [main]
-  
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+defaults:
+  run:
+    working-directory: ${{ env.tf_actions_working_dir }}
 
 jobs:
   fmt-check:
     name: Check terraform formatting issues
     runs-on: ubuntu-latest
     steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-
-    - name: terraform fmt -check -recursive .
-      uses: dflook/terraform-fmt-check@v1
-      with:
-        path: dev
+    - uses: hashicorp/setup-terraform@v2
+    
+    - name: Terraform fmt
+      id: fmt
+      run: terraform fmt -check
+      continue-on-error: true
 
   validate:
+    name: Check terraform formatting issues
     runs-on: ubuntu-latest
-    name: Validate terraform configuration
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+    - uses: hashicorp/setup-terraform@v2
 
-      - name: terraform validate
-        uses: dflook/terraform-validate@v1
-        with:
-          path: dev
+    - name: Terraform validate
+      id: validate
+      run: terraform fmt -check
+      continue-on-error: true
 
-  plan:
-    name: Terraform plan
+  pre-plan:
+    name: Setup aws creds and install K8s dependencies
     runs-on: ubuntu-latest
-
     steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-    
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-west-2
-    
     # There's got to be a better way!
     - name: Add profile credentials to ~/.aws/credentials 
       run: |
@@ -65,10 +55,152 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y helm
 
-    - name: terraform plan
-      uses: dflook/terraform-plan@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        AWS_SHARED_CREDENTIALS_FILE: /github/workspace/.aws/credentials
+  plan:
+    name: Check terraform formatting issues
+    runs-on: ubuntu-latest
+    steps:
+    - uses: hashicorp/setup-terraform@v2
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
       with:
-        path: dev
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
+
+    - name: Terraform plan
+      id: validate
+      run: terraform plan -no-color
+      continue-on-error: true        
+
+  post-plans:
+    name: post plan as a comment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add or Update comment
+        uses: actions/github-script@v6
+        if: github.event_name == 'pull_request'
+        env:
+          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // 1. Retrieve existing bot comments for the PR
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const botComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes('Terraform Format and Style')
+            })
+
+            // 2. Prepare format of the comment
+            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+            <details><summary>Validation Output</summary>
+
+            \`\`\`\n
+            ${{ steps.validate.outputs.stdout }}
+            \`\`\`
+
+            </details>
+
+            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+            
+            <details><summary>Show Plan</summary>
+            
+            \`\`\`\n
+            ${process.env.PLAN}
+            \`\`\`
+            
+            </details>
+            
+            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.tf_actions_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
+            
+            // 3. If we have a comment, update it, otherwise create a new one
+            if (botComment) {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: output
+              })
+            } else {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              })
+            }
+
+
+# jobs:
+#   fmt-check:
+#     name: Check terraform formatting issues
+#     runs-on: ubuntu-latest
+#     steps:
+#     - name: Check out code
+#       uses: actions/checkout@v2
+
+#     - name: terraform fmt -check -recursive .
+#       uses: dflook/terraform-fmt-check@v1
+#       with:
+#         path: dev
+
+#   validate:
+#     runs-on: ubuntu-latest
+#     name: Validate terraform configuration
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v2
+
+#       - name: terraform validate
+#         uses: dflook/terraform-validate@v1
+#         with:
+#           path: dev
+
+#   plan:
+#     name: Terraform plan
+#     runs-on: ubuntu-latest
+
+#     steps:
+#     - name: Check out code
+#       uses: actions/checkout@v2
+    
+#     - name: Configure AWS credentials
+#       uses: aws-actions/configure-aws-credentials@v1
+#       with:
+#         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#         aws-region: us-west-2
+    
+#     # There's got to be a better way!
+#     - name: Add profile credentials to ~/.aws/credentials 
+#       run: |
+#         aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }} --profile angi-dev
+#         aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }} --profile angi-dev
+#         mkdir -p .aws
+#         echo "[angi-dev]" > .aws/credentials
+#         echo "aws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}" >> .aws/credentials
+#         echo "aws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> .aws/credentials
+    
+#     - name: Install K8s dependencies
+#       run: |
+#         sudo curl -o /usr/local/bin/kubectl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+#         sudo chmod +x /usr/local/bin/kubectl
+#         curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+#         sudo apt-get install apt-transport-https unzip -y
+#         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+#         sudo apt-get update
+#         sudo apt-get install -y helm
+
+#     - name: terraform plan
+#       uses: dflook/terraform-plan@v1
+#       env:
+#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#         AWS_SHARED_CREDENTIALS_FILE: /github/workspace/.aws/credentials
+#       with:
+#         path: dev

--- a/.github/workflows/tfplan.yaml
+++ b/.github/workflows/tfplan.yaml
@@ -2,205 +2,109 @@ name: Terraform plan Dev env
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
-
-defaults:
-  run:
-    working-directory: ${{ env.tf_actions_working_dir }}
 
 jobs:
-  fmt-check:
-    name: Check terraform formatting issues
+
+  plan:
+    name: Terraform plan
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: dev
     steps:
+    - uses: actions/checkout@v2
     - uses: hashicorp/setup-terraform@v2
-    
+
     - name: Terraform fmt
       id: fmt
       run: terraform fmt -check
-      continue-on-error: true
 
-  validate:
-    name: Check terraform formatting issues
-    runs-on: ubuntu-latest
-    steps:
-    - uses: hashicorp/setup-terraform@v2
-
-    - name: Terraform validate
-      id: validate
-      run: terraform fmt -check
-      continue-on-error: true
-
-  pre-plan:
-    name: Setup aws creds and install K8s dependencies
-    runs-on: ubuntu-latest
-    steps:
-    # There's got to be a better way!
     - name: Add profile credentials to ~/.aws/credentials 
       run: |
-        aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }} --profile angi-dev
-        aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }} --profile angi-dev
-        mkdir -p .aws
-        echo "[angi-dev]" > .aws/credentials
-        echo "aws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}" >> .aws/credentials
-        echo "aws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> .aws/credentials
-    
-    - name: Install K8s dependencies
-      run: |
-        sudo curl -o /usr/local/bin/kubectl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-        sudo chmod +x /usr/local/bin/kubectl
-        curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
-        sudo apt-get install apt-transport-https unzip -y
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-        sudo apt-get update
-        sudo apt-get install -y helm
-
-  plan:
-    name: Check terraform formatting issues
-    runs-on: ubuntu-latest
-    steps:
-    - uses: hashicorp/setup-terraform@v2
+        mkdir -p ~/.aws
+        echo "[angi-dev]" > ~/.aws/credentials
+        echo "aws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}" >> ~/.aws/credentials
+        echo "aws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> ~/.aws/credentials
+        echo "role_arn=arn:aws:iam::013593650453:role/access_angitest_dev-eks_cluster" >> ~/.aws/credentials
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: arn:aws:iam::013593650453:role/access_angitest_dev-eks_cluster
+        role-skip-session-tagging: true
+        role-duration-seconds: 1200
         aws-region: us-west-2
 
-    - name: Terraform plan
-      id: validate
-      run: terraform plan -no-color
-      continue-on-error: true        
+    - name: Terraform Init
+      id: init
+      run: terraform init
 
-  post-plans:
-    name: post plan as a comment
-    runs-on: ubuntu-latest
-    steps:
-      - name: Add or Update comment
-        uses: actions/github-script@v6
-        if: github.event_name == 'pull_request'
-        env:
-          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            // 1. Retrieve existing bot comments for the PR
-            const { data: comments } = await github.rest.issues.listComments({
+    - name: Terraform validate
+      id: validate
+      run: terraform validate -no-color
+
+    - name: Terraform plan
+      id: plan
+      run: terraform plan -no-color
+      
+    - name: Add or Update comment
+      uses: actions/github-script@v6
+      if: github.event_name == 'pull_request'
+      env:
+        PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          // 1. Retrieve existing bot comments for the PR
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+          })
+          const botComment = comments.find(comment => {
+            return comment.user.type === 'Bot' && comment.body.includes('Terraform Format and Style')
+          })
+
+          // 2. Prepare format of the comment
+          const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+          #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+          #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+          <details><summary>Validation Output</summary>
+
+          \`\`\`\n
+          ${{ steps.validate.outputs.stdout }}
+          \`\`\`
+
+          </details>
+
+          #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+          
+          <details><summary>Show Plan</summary>
+          
+          \`\`\`\n
+          ${process.env.PLAN}
+          \`\`\`
+          
+          </details>
+          
+          *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.tf_actions_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
+          
+          // 3. If we have a comment, update it, otherwise create a new one
+          if (botComment) {
+            github.rest.issues.updateComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
+              comment_id: botComment.id,
+              body: output
+            })
+          } else {
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
             })
-            const botComment = comments.find(comment => {
-              return comment.user.type === 'Bot' && comment.body.includes('Terraform Format and Style')
-            })
-
-            // 2. Prepare format of the comment
-            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
-            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
-            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
-            <details><summary>Validation Output</summary>
-
-            \`\`\`\n
-            ${{ steps.validate.outputs.stdout }}
-            \`\`\`
-
-            </details>
-
-            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
-            
-            <details><summary>Show Plan</summary>
-            
-            \`\`\`\n
-            ${process.env.PLAN}
-            \`\`\`
-            
-            </details>
-            
-            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.tf_actions_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
-            
-            // 3. If we have a comment, update it, otherwise create a new one
-            if (botComment) {
-              github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: output
-              })
-            } else {
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: output
-              })
-            }
-
-
-# jobs:
-#   fmt-check:
-#     name: Check terraform formatting issues
-#     runs-on: ubuntu-latest
-#     steps:
-#     - name: Check out code
-#       uses: actions/checkout@v2
-
-#     - name: terraform fmt -check -recursive .
-#       uses: dflook/terraform-fmt-check@v1
-#       with:
-#         path: dev
-
-#   validate:
-#     runs-on: ubuntu-latest
-#     name: Validate terraform configuration
-#     steps:
-#       - name: Checkout
-#         uses: actions/checkout@v2
-
-#       - name: terraform validate
-#         uses: dflook/terraform-validate@v1
-#         with:
-#           path: dev
-
-#   plan:
-#     name: Terraform plan
-#     runs-on: ubuntu-latest
-
-#     steps:
-#     - name: Check out code
-#       uses: actions/checkout@v2
-    
-#     - name: Configure AWS credentials
-#       uses: aws-actions/configure-aws-credentials@v1
-#       with:
-#         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#         aws-region: us-west-2
-    
-#     # There's got to be a better way!
-#     - name: Add profile credentials to ~/.aws/credentials 
-#       run: |
-#         aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }} --profile angi-dev
-#         aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }} --profile angi-dev
-#         mkdir -p .aws
-#         echo "[angi-dev]" > .aws/credentials
-#         echo "aws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}" >> .aws/credentials
-#         echo "aws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> .aws/credentials
-    
-#     - name: Install K8s dependencies
-#       run: |
-#         sudo curl -o /usr/local/bin/kubectl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-#         sudo chmod +x /usr/local/bin/kubectl
-#         curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
-#         sudo apt-get install apt-transport-https unzip -y
-#         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-#         sudo apt-get update
-#         sudo apt-get install -y helm
-
-#     - name: terraform plan
-#       uses: dflook/terraform-plan@v1
-#       env:
-#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#         AWS_SHARED_CREDENTIALS_FILE: /github/workspace/.aws/credentials
-#       with:
-#         path: dev
+          }

--- a/dev/outputs.tf
+++ b/dev/outputs.tf
@@ -32,3 +32,8 @@ output "configure_kubectl" {
   description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
   value       = module.eks_cluster.configure_kubectl
 }
+
+output "assume_role_to_access_eks" {
+  description = "If your user has appropriate tags, assume this role before running eks update-kubeconfig command to access k8s cluster"
+  value       = aws_iam_role.to_access_eks_cluster.arn
+}

--- a/modules/ci-user/main.tf
+++ b/modules/ci-user/main.tf
@@ -94,7 +94,9 @@ data "aws_iam_policy_document" "allow_ecr_push" {
       "iam:GetOpenIDConnectProvider",
       "eks:DescribeAddon",
       "iam:GetInstanceProfile",
-      "eks:DescribeNodegroup"
+      "eks:DescribeNodegroup",
+      "eks:ListClusters"
+
     ]
     resources = ["*"]
   }

--- a/modules/ci-user/main.tf
+++ b/modules/ci-user/main.tf
@@ -23,7 +23,7 @@ resource "aws_iam_group_membership" "main" {
   group = aws_iam_group.cigroup.name
 }
 
-data "aws_iam_policy_document" "allow_ecr_push" {
+data "aws_iam_policy_document" "for_ci_user" {
   statement {
     actions = [
       "ecr:GetAuthorizationToken",
@@ -52,64 +52,20 @@ data "aws_iam_policy_document" "allow_ecr_push" {
     ]
   }
 
-  # Special statement to allow github user be able to run terraform plans
-  # generated using iamlive and running terraform plan
   statement {
-    actions = [
-      "s3:ListBucket",
-      "s3:GetObject",
-      "ec2:DescribeAccountAttributes",
-      "ec2:DescribeAvailabilityZones",
-      "ecr:DescribeRepositories",
-      "ec2:DescribeVpcs",
-      "ecr:ListTagsForResource",
-      "ec2:DescribeVpcClassicLink",
-      "ecr:GetLifecyclePolicy",
-      "ec2:DescribeVpcClassicLinkDnsSupport",
-      "ec2:DescribeVpcAttribute",
-      "iam:GetGroup",
-      "iam:GetUser",
-      "ec2:DescribeNetworkAcls",
-      "ecr:GetRepositoryPolicy",
-      "ec2:DescribeAddresses",
-      "ec2:DescribeRouteTables",
-      "ec2:DescribeSecurityGroups",
-      "iam:GetPolicy",
-      "kms:DescribeKey",
-      "iam:GetRole",
-      "kms:GetKeyPolicy",
-      "kms:GetKeyRotationStatus",
-      "iam:GetPolicyVersion",
-      "ec2:DescribeSubnets",
-      "kms:ListResourceTags",
-      "ec2:DescribeInternetGateways",
-      "kms:ListAliases",
-      "iam:ListAttachedGroupPolicies",
-      "ec2:DescribeNatGateways",
-      "iam:ListRolePolicies",
-      "iam:ListAttachedRolePolicies",
-      "eks:DescribeCluster",
-      "ec2:DescribeTags",
-      "eks:DescribeAddonVersions",
-      "iam:GetOpenIDConnectProvider",
-      "eks:DescribeAddon",
-      "iam:GetInstanceProfile",
-      "eks:DescribeNodegroup",
-      "eks:ListClusters"
-
-    ]
+    actions   = ["sts:AssumeRole"]
     resources = ["*"]
   }
 }
 
-resource "aws_iam_policy" "allow_ecr_push" {
+resource "aws_iam_policy" "for_ci_user" {
   name        = "${lower(var.ci_name)}-ecr-${var.ecr_repo}-policy"
   description = "Allow ${var.ci_name} to push new ${var.ecr_repo} ECR images"
   path        = "/"
-  policy      = data.aws_iam_policy_document.allow_ecr_push.json
+  policy      = data.aws_iam_policy_document.for_ci_user.json
 }
 
 resource "aws_iam_group_policy_attachment" "main" {
   group      = aws_iam_group.cigroup.name
-  policy_arn = aws_iam_policy.allow_ecr_push.arn
+  policy_arn = aws_iam_policy.for_ci_user.arn
 }

--- a/modules/ci-user/outputs.tf
+++ b/modules/ci-user/outputs.tf
@@ -1,0 +1,7 @@
+output "user_arn" {
+  value = aws_iam_user.ci.arn
+}
+
+output "user_name" {
+  value = aws_iam_user.ci.name
+}

--- a/modules/ci-user/variables.tf
+++ b/modules/ci-user/variables.tf
@@ -15,7 +15,7 @@ variable "ci_project" {
 }
 
 variable "common_tags" {
-  type = map(string)
+  type        = map(string)
   description = "Common tags to be applied to CI user"
-  default = {}
+  default     = {}
 }

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -1,5 +1,7 @@
 locals {
-  additional_iam_policies_for_nodegroups = length(var.additional_iam_policies_for_nodegroups) > 0 ? var.additional_iam_policies_for_nodegroups: []
+  additional_iam_policies_for_nodegroups = length(var.additional_iam_policies_for_nodegroups) > 0 ? var.additional_iam_policies_for_nodegroups : []
+  map_users                              = length(var.list_of_maps_of_authenticated_users) > 0 ? var.list_of_maps_of_authenticated_users : []
+  map_roles                              = length(var.list_of_maps_of_authenticated_roles) > 0 ? var.list_of_maps_of_authenticated_roles : []
 }
 
 data "aws_caller_identity" "current" {}
@@ -7,13 +9,16 @@ data "aws_caller_identity" "current" {}
 module "eks_blueprints" {
   source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.3.0"
 
-  cluster_name = var.cluster_name
+  cluster_name    = var.cluster_name
   cluster_version = var.kubernetes_version
 
-  vpc_id = var.vpc_id
+  vpc_id             = var.vpc_id
   private_subnet_ids = var.private_subnet_ids
 
   cluster_kms_key_additional_admin_arns = [data.aws_caller_identity.current.arn]
+
+  map_users = local.map_users
+  map_roles = local.map_roles
 
   node_security_group_additional_rules = {
     # Extend node-to-node security group rules. Recommended and required for the Add-ons
@@ -56,14 +61,14 @@ module "eks_blueprints" {
       enable_monitoring = true
       eni_delete        = true
 
-      subnet_type     = "private"
-      subnet_ids      = var.private_subnet_ids
+      subnet_type = "private"
+      subnet_ids  = var.private_subnet_ids
 
       desired_size = 3
       max_size     = 10
       min_size     = 2
 
-      disk_size       = 100 
+      disk_size = 100
       update_config = [{
         max_unavailable_percentage = 30
       }]
@@ -75,21 +80,21 @@ module "eks_blueprints" {
         "k8s.io/cluster-autoscaler/node-template/label/eks/node_group_name"            = "spot-2vcpu-8mem"
       }
     }
-  spot_4vcpu_16mem = {
-    node_group_name   = "managed-spot-4vcpu-16mem"
+    spot_4vcpu_16mem = {
+      node_group_name   = "managed-spot-4vcpu-16mem"
       capacity_type     = "SPOT"
       instance_types    = ["m5.xlarge", "m4.xlarge", "m6a.xlarge", "m5a.xlarge", "m5d.xlarge"]
       enable_monitoring = true
       eni_delete        = true
 
-      subnet_type     = "private"
-      subnet_ids      = var.private_subnet_ids
+      subnet_type = "private"
+      subnet_ids  = var.private_subnet_ids
 
       desired_size = 3
       max_size     = 10
       min_size     = 2
 
-      disk_size       = 100 
+      disk_size = 100
       update_config = [{
         max_unavailable_percentage = 30
       }]

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -20,10 +20,10 @@ output "configure_kubectl" {
 
 output "kubernetes_version" {
   description = "Kubernetes version running in cluster"
-  value = module.eks_blueprints.eks_cluster_version
+  value       = module.eks_blueprints.eks_cluster_version
 }
 
 output "oidc_provider" {
   description = "OIDC provider for the EKS cluster"
-  value = module.eks_blueprints.oidc_provider
+  value       = module.eks_blueprints.oidc_provider
 }

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -1,37 +1,75 @@
 variable "cluster_name" {
-  type = string
+  type        = string
   description = "Name of the EKS cluster"
 }
 
 variable "additional_iam_policies_for_nodegroups" {
-  type = list
+  type        = list(any)
   description = "Additional IAM policies to be applied to nodegroups"
-  default = []
+  default     = []
 }
 
 variable "region" {
-  type = string
+  type        = string
   description = "Region to spin up EKS cluster in"
-  default = "us-west-2"
+  default     = "us-west-2"
 }
 
 variable "kubernetes_version" {
-  type = string
+  type        = string
   description = "EKS Kubernetes version to use"
-  default = "1.22"
+  default     = "1.22"
 }
 
 variable "vpc_id" {
-  type = string
+  type        = string
   description = "VPC Id for the VPC created for EKS cluster"
 }
 
 variable "private_subnet_ids" {
-  type = list(string)
+  type        = list(string)
   description = "Ids of private subnets to be used with fargate"
 }
 
 variable "eks_tags" {
-  type = map(string)
+  type        = map(string)
   description = "Tags to be applied to the EKS cluster"
+}
+
+variable "list_of_maps_of_authenticated_users" {
+  type = list(object({
+    userarn  = string
+    username = string
+    groups   = list(string)
+  }))
+  description = <<-EOT
+  List of map of users that are allowed to access the cluster. E.g.
+  [
+    {
+      userarn  = "arn:aws:iam::<aws-account-id>:user/<username>"         # The ARN of the IAM user to add.
+      username = "<username>"                                            # The user name within Kubernetes to map to the IAM user
+      groups   = ["system:masters"]                                      # A list of groups within Kubernetes to which the role is mapped; Checkout K8s Role and Rolebindings
+    }
+  ]
+  EOT
+  default     = []
+}
+
+variable "list_of_maps_of_authenticated_roles" {
+  type = list(object({
+    rolearn  = string
+    username = string
+    groups   = list(string)
+  }))
+  description = <<-EOT
+  List of map of users that are allowed to access the cluster. E.g.
+  [
+    {
+      rolearn  = "arn:aws:iam::<aws-account-id>:role/<role_name>"         # The ARN of the IAM role
+      username = "<username>"                                            # The user name within Kubernetes to map to the IAM role
+      groups   = ["system:masters"]                                      # A list of groups within Kubernetes to which the role is mapped; Checkout K8s Role and Rolebindings
+    }
+  ]
+  EOT
+  default     = []
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,34 +1,34 @@
 data "aws_availability_zones" "azs" {
-    state = "available"
+  state = "available"
 }
 
 locals {
   common_vpc_tags = merge(var.common_vpc_tags, { "kubernetes.io/cluster/${var.name_prefix}-eks" = "shared" })
   total_azs_count = length(data.aws_availability_zones.azs.zone_ids)
   newbits         = log(var.total_subnets, 2)
-  all_subnets     = tolist([for i in range(var.total_subnets): cidrsubnet(var.vpc_cidr, local.newbits, i)])
+  all_subnets     = tolist([for i in range(var.total_subnets) : cidrsubnet(var.vpc_cidr, local.newbits, i)])
 }
 
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
   version = "3.14.0"
 
   name = "${var.name_prefix}-vpc"
   cidr = var.vpc_cidr
-  azs = data.aws_availability_zones.azs.names
+  azs  = data.aws_availability_zones.azs.names
 
   # Split public and private subnets evenly. Not the best way but its okay for now
-  public_subnets = slice(local.all_subnets, 0, local.total_azs_count)
+  public_subnets  = slice(local.all_subnets, 0, local.total_azs_count)
   private_subnets = slice(reverse(local.all_subnets), 0, local.total_azs_count)
 
   enable_nat_gateway            = true
-  single_nat_gateway            = true   # Save some $$$ but spof
+  single_nat_gateway            = true # Save some $$$ but spof
   enable_dns_hostnames          = true
   manage_default_network_acl    = true
   manage_default_route_table    = true
   manage_default_security_group = true
-  reuse_nat_ips                 = false  # Destroying VPC will release the EIP
-  one_nat_gateway_per_az        = false  # Save some $$$ but spof
+  reuse_nat_ips                 = false # Destroying VPC will release the EIP
+  one_nat_gateway_per_az        = false # Save some $$$ but spof
 
   tags = var.common_vpc_tags
 

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,34 +1,34 @@
 output "vpc_id" {
   description = "VPC ID created by module"
-  value = module.vpc.vpc_id
+  value       = module.vpc.vpc_id
 }
 
 output "vpc_arn" {
   description = "ARN of the vpc create by this module"
-  value = module.vpc.vpc_arn
+  value       = module.vpc.vpc_arn
 }
 
 output "public_subnet_ids" {
   description = "Public subnet ids"
-  value = module.vpc.public_subnets
+  value       = module.vpc.public_subnets
 }
 
 output "private_subnet_ids" {
   description = "Private subnet ids"
-  value = module.vpc.private_subnets
+  value       = module.vpc.private_subnets
 }
 
 output "nat_public_ips" {
   description = "Nat gw EIPs"
-  value = module.vpc.nat_public_ips
+  value       = module.vpc.nat_public_ips
 }
 
 output "nat_gw_ids" {
   description = "Nat gw Ids"
-  value = module.vpc.natgw_ids
+  value       = module.vpc.natgw_ids
 }
 
 output "azs" {
   description = "AZs supported by the module"
-  value = data.aws_availability_zones.azs.names
+  value       = data.aws_availability_zones.azs.names
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -1,20 +1,20 @@
 variable "name_prefix" {
-  type = string
+  type        = string
   description = "Name to be used as a prefix for VPC resources"
 }
 
 variable "vpc_cidr" {
-  type = string
+  type        = string
   description = "CIDR block for VPC"
 }
 
 variable "total_subnets" {
-  type = number
+  type        = number
   description = "Total number of subnets required. Must be power of 2. e.g. 8, 16, 32, 64..."
-  default = 16
+  default     = 16
 }
 
 variable "common_vpc_tags" {
-  type = map(string)
+  type        = map(string)
   description = "Additional tags to be applied to the VPC and all private and public subnets in VPC"
 }


### PR DESCRIPTION
## Changes

- Use official terraform provider
- Create an iam policy for `allow_tf_plans` and attach it to `to_access_eks_cluster` role that users with tag: `eks_cluster:<clustername>` can assume.
- Update aws-auth configmap to allow users with the above tag to be able to obtain kubeconfig file 

## Known Issues
- There are some KMS key access policies that depends on the user arn of the user creating the cluster. Because of this terraform plan in CI will always show changes. This needs to be fixed.
- I dont want to add github user any write priviledges to AWS infra. So no running terraform apply (access restricted by the`allow_tf_plans` policy)